### PR TITLE
Add a guard to check for SHIPPING_API_LEVEL

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -12,7 +12,10 @@ LOCAL_JAVA_LIBRARIES :=	android.hidl.manager-V1.0-java
 LOCAL_STATIC_JAVA_LIBRARIES := vendor.qti.hardware.radio.am-V1.0-java
 
 LOCAL_PROGUARD_FLAG_FILES := proguard.flags
-LOCAL_PRIVATE_PLATFORM_APIS := true
 LOCAL_PRIVILEGED_MODULE := true
+
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
 
 include $(BUILD_PACKAGE)


### PR DESCRIPTION
Lets add a guard to check for shipping api level and if its equal to SDK version.

This fixes error in building if shipping api level is equal to SDK version.

`Specifies both LOCAL_SDK_VERSION (system_current) and LOCAL_PRIVATE_PLATFORM_APIS (true) but should specify only one`