### PR TITLE
Android.bp: Remove unused proguard files.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17,8 +17,5 @@ android_app {
 
     static_libs: ["vendor.qti.hardware.radio.am-V1.0-java"],
 
-    optimize: {
-        proguard_flags_files: ["proguard.flags"],
-    },
     sdk_version: "system_current",
 }

--- a/proguard.flags
+++ b/proguard.flags
@@ -1,7 +1,0 @@
--keep class com.sony.qcrilam.BootReceiver {
-      *;
-}
-
--keep class com.sony.qcrilam.QcrRilAmService {
-      *;
-}


### PR DESCRIPTION
R8 takes care of enough optimization already. Proguard together with the
migration to .bp breaks the build on Android 9 due to
https://r.android.com/688498

Yes, I broke the build once again even after testing it and thinking this was a local fluke :see_no_evil: 