### PR TITLE
[QCRILAM] Remove sharedUserId

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.sony.qcrilam"
     coreApp="true"
-    android:sharedUserId="android.uid.system"
     android:versionCode="1"
     android:versionName="1.0" >
 

--- a/src/com/sony/qcrilam/QcRilAmService.kt
+++ b/src/com/sony/qcrilam/QcRilAmService.kt
@@ -30,9 +30,9 @@ import android.util.Log
 import vendor.qti.hardware.radio.am.V1_0.IQcRilAudio
 import vendor.qti.hardware.radio.am.V1_0.IQcRilAudioCallback
 
-class QcRilAmService : Service() {
-    private var TAG = "QcRilAm-Service"
+private const val TAG = "QcRilAm-Service"
 
+class QcRilAmService : Service() {
     private fun addCallbackForSimSlot(simSlotNo: Int, audioManager: AudioManager) {
         try {
             val qcRilAudio = IQcRilAudio.getService("slot$simSlotNo")
@@ -58,9 +58,7 @@ class QcRilAmService : Service() {
         }
     }
 
-    override fun onBind(intent: Intent?): IBinder? {
-        return null
-    }
+    override fun onBind(intent: Intent?) = null
 
     override fun onCreate() {
         val simCount = getSystemService(SubscriptionManager::class.java).getActiveSubscriptionInfoCountMax()


### PR DESCRIPTION
sharedUserId is a deprecated flag [1] that muddies the waters when it
comes to enforcement of various policies and permissions. QcRilAm
doesn't use any and operates just fine within normal app boundaries
(uses public APIs, doesn't need any permissions outside "normal" ones,
and accesses vendor services properly over Binder).
This also allows the signing key to differ from platform, where other
android.uid.system apps are signed with.

[1]: https://developer.android.com/guide/topics/manifest/manifest-element#uid

--

Tested on Akatsuki DSDS: Android automatically handles the switch away from sharedUserId, and in-call audio still works.