### PR TITLE
QcRilAmService: Wait for IQcRilAudio to be up

### DIFF
--- a/src/com/sony/qcrilam/QcRilAmService.kt
+++ b/src/com/sony/qcrilam/QcRilAmService.kt
@@ -35,7 +35,7 @@ class QcRilAmService : Service() {
 
     private fun addCallbackForSimSlot(simSlotNo: Int, audioManager: AudioManager) {
         try {
-            val qcRilAudio = IQcRilAudio.getService("slot$simSlotNo")
+            val qcRilAudio = IQcRilAudio.getService("slot$simSlotNo", true /*retry*/)
             if (qcRilAudio == null) {
                 Log.e(TAG, "Could not get service instance for slot$simSlotNo, failing")
             } else {


### PR DESCRIPTION
The default call to getService of a HIDL/AIDL interface will not wait for the service to be up. Use the `retry` parameter to use` tryGetService` internally.

This will fix a deprecation warning on future Android versions.

See https://android-review.googlesource.com/c/platform/system/tools/hidl/+/1291900